### PR TITLE
Remove duplicate labels

### DIFF
--- a/src/part_1/chapter_8/exercises/E86-paintfactoryextended.tex
+++ b/src/part_1/chapter_8/exercises/E86-paintfactoryextended.tex
@@ -1,8 +1,8 @@
 Recall the paint factory problem 
 %
 \begin{flalign}
-	\maxi z = \ & 5x_1 + 4x_2 \label{p1c1:eq:constM1}\\
-	\st & 6x_1 + 4x_2 \leq 24 \label{p1c1:eq:constM2}\\
+	\maxi z = \ & 5x_1 + 4x_2 \\
+	\st & 6x_1 + 4x_2 \leq 24 \\
 	& x_1 + 2x_2 \leq 6 \\
 	& x_2 - x_1 \leq  1 \\
 	& x_2 \leq 2 \\


### PR DESCRIPTION
The new exercise contained a model copied directly from chapter 1, with the respective labels. The labels should probably be removed so we don't get weird cross-references in the notes...